### PR TITLE
Initial work on Video Village Raspberry Pi API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,13 @@
+video village pi
+================
+The software and services powering each Raspberry Pi installed in
+the Video Village as part of http://seeingspartanburg.com
+
+Installation:
+-------------
+With a fresh SD card based on https://downloads.raspberrypi.org/raspbian_lite_latest ,
+you can run the pi-setup.sh script to install the necessary
+dependencies.
+::
+
+    ./pi-setup.sh

--- a/README.rst
+++ b/README.rst
@@ -11,3 +11,61 @@ dependencies.
 ::
 
     ./pi-setup.sh
+
+
+Starting the API services
+-------------------------
+The Video Village Raspberry Pi API may be deployed and run
+using your favorite WSGI HTTP server.  Here's an example using gunicorn:
+
+::
+
+    gunicorn -w 4 -k gevent -b 0.0.0.0:5000 video:app
+
+
+Interacting with the Video Village Raspberry Pis
+------------------------------------------------
+
+Check the status information for a specific Pi
+
+::
+
+    curl http://IP_ADDRESS:5000/status
+    {
+      "encoder_active": false,
+      "hardware_address": "00:00:00:00:00:00",
+      "player_active": false
+    }
+
+Play a specific video that's been previously sync'ed to the Pi
+
+::
+
+    curl -H "Content-Type: application/json" -XPOST -d '{"video": "test.mp4"}' http://IP_ADDRESS:5000/play
+    {
+      "audio": {
+      "bps": 16,
+      "channels": 6,
+      "decoder": "aac",
+      "rate": 48000
+      },
+      "status": "running",
+      "video": {
+      "decoder": "omx-h264",
+      "dimensions": [
+        640,
+        480
+      ],
+      "fps": 25.0,
+      "profile": 77
+      }
+    }
+
+Transcode a video that's been previously sync'ed to the Pi
+
+::
+
+    curl -H "Content-Type: application/json" -XPOST -d '{"source_file": "test.mp4", "target_file": "test_800x600.mp4", "width": 800, "height": 600}' http://IP_ADDRESS:5000/transcode
+    {
+    "status": "running"
+    }

--- a/pi-setup.sh
+++ b/pi-setup.sh
@@ -1,0 +1,44 @@
+# set up fresh raspbian jessy lite install for video village usage
+# https://downloads.raspberrypi.org/raspbian_lite_latest
+sudo apt-get update
+
+# Video Village Pis will use omxplayer for video playback
+sudo apt-get install -y omxplayer
+
+# use GStreamer for video transcoding
+sudo apt-get install -y libgstreamer1.0-0 libgstreamer1.0-0-dbg \
+                        libgstreamer1.0-dev liborc-0.4-0 liborc-0.4-0-dbg \
+                        liborc-0.4-dev liborc-0.4-doc \
+                        gir1.2-gst-plugins-base-1.0 gir1.2-gstreamer-1.0 \
+                        gstreamer1.0-alsa gstreamer1.0-doc gstreamer1.0-omx \
+                        gstreamer1.0-plugins-bad gstreamer1.0-plugins-bad-dbg \
+                        gstreamer1.0-plugins-bad-doc gstreamer1.0-plugins-base \
+                        gstreamer1.0-plugins-base-apps \
+                        gstreamer1.0-plugins-base-dbg \
+                        gstreamer1.0-plugins-base-doc gstreamer1.0-plugins-good \
+                        gstreamer1.0-plugins-good-dbg gstreamer1.0-plugins-good-doc \
+                        gstreamer1.0-plugins-ugly gstreamer1.0-plugins-ugly-dbg \
+                        gstreamer1.0-plugins-ugly-doc gstreamer1.0-pulseaudio \
+                        gstreamer1.0-tools gstreamer1.0-x \
+                        libgstreamer-plugins-bad1.0-0 \
+                        libgstreamer-plugins-bad1.0-dev \
+                        libgstreamer-plugins-base1.0-0 \
+                        libgstreamer-plugins-base1.0-dev
+
+
+#Set up Python related components
+sudo apt-get install -y libffi5 python-virtualenv git
+curl -L https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.1-linux-armhf-raspbian.tar.bz2 \
+     -o pypy2-v5.3.1-linux-armhf-raspbian.tar.bz2
+sudo tar -xjf pypy2-v5.3.1-linux-armhf-raspbian.tar.bz2 -C /usr/local --strip-components=1
+
+virtualenv -p pypy video-env
+source video-env/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+
+#TODO: set up services to keep video village pi API running after restarts, etc
+
+#TODO: use nginx with https://letsencrypt.org for SSL certificate management
+
+#TODO: configure remote access and monitoring

--- a/pyomxplayer.py
+++ b/pyomxplayer.py
@@ -1,0 +1,81 @@
+# pyomxplayer based on https://github.com/jbaiter/pyomxplayer
+import pexpect
+import re
+
+from threading import Thread
+from time import sleep
+
+
+class OMXPlayer(object):
+
+    _FILEPROP_REXP = re.compile(r".*audio streams (\d+) video streams (\d+) chapters (\d+) subtitles (\d+).*")
+    _VIDEOPROP_REXP = re.compile(r".*Video codec ([\w-]+) width (\d+) height (\d+) profile (-?\d+) fps ([\d.]+).*")
+    _AUDIOPROP_REXP = re.compile(r"Audio codec (\w+) channels (\d+) samplerate (\d+) bitspersample (\d+).*")
+    _STATUS_REXP = re.compile(r"M:\s*(\d+).*")
+    _DONE_REXP = re.compile(r"have a nice day.*")
+
+    _LAUNCH_CMD = '/usr/bin/omxplayer -s %s %s'
+    _PAUSE_CMD = 'p'
+    _TOGGLE_SUB_CMD = 's'
+    _QUIT_CMD = 'q'
+    _FASTER_CMD = '2'
+    _SLOWER_CMD = '1'
+
+    paused = False
+    subtitles_visible = True
+
+    def __init__(self, mediafile, args=None, start_playback=False):
+        if not args:
+            args = ""
+        cmd = self._LAUNCH_CMD % (mediafile, args)
+        self._process = pexpect.spawn(cmd)
+
+        self.video = dict()
+        self.audio = dict()
+        # Get video properties
+        video_props = self._VIDEOPROP_REXP.match(self._process.readline()).groups()
+        self.video['decoder'] = video_props[0]
+        self.video['dimensions'] = tuple(int(x) for x in video_props[1:3])
+        self.video['profile'] = int(video_props[3])
+        self.video['fps'] = float(video_props[4])
+        # Get audio properties
+        audio_props = self._AUDIOPROP_REXP.match(self._process.readline()).groups()
+        self.audio['decoder'] = audio_props[0]
+        (self.audio['channels'], self.audio['rate'],
+         self.audio['bps']) = [int(x) for x in audio_props[1:]]
+
+        self.finished = False
+        self.position = 0
+
+        self._position_thread = Thread(target=self._get_position)
+        self._position_thread.start()
+
+        if start_playback:
+            self.toggle_pause()
+        self.toggle_subtitles()
+
+    def _get_position(self):
+        while True:
+            index = self._process.expect([self._STATUS_REXP,
+                                            pexpect.TIMEOUT,
+                                            pexpect.EOF,
+                                            self._DONE_REXP])
+            if index == 1: continue
+            elif index in (2, 3):
+                self.finished = True
+                break
+            else:
+                self.position = float(self._process.match.group(1))
+            sleep(0.05)
+
+    def toggle_pause(self):
+        if self._process.send(self._PAUSE_CMD):
+            self.paused = not self.paused
+
+    def toggle_subtitles(self):
+        if self._process.send(self._TOGGLE_SUB_CMD):
+            self.subtitles_visible = not self.subtitles_visible
+
+    def stop(self):
+        self._process.send(self._QUIT_CMD)
+        self._process.terminate(force=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Flask==0.11.1
+gevent==1.1.1
+gunicorn==19.6.0
+ipython==5.0.0
+pexpect==4.2.0

--- a/video.py
+++ b/video.py
@@ -1,12 +1,13 @@
 import flask
-from flask import Flask
+from flask import Flask, request
 import socket
 import fcntl
 import struct
 
-import pyomxplayer
+import omx
 
 player = None
+encoder = None
 
 
 def get_ip_address(ifname):
@@ -27,22 +28,41 @@ def get_hardware_address(ifname):
 app = Flask(__name__)
 
 #TODO: secure these routes such that only authorized clients may access
-@app.route("/play", method="POST")
-def play_video():
+@app.route("/play", methods=["POST"])
+def play():
     global player
     if player:
         # stop playback if a video has already been started
         player.stop()
 
-    video_file_name = ''
-    player = pyomxplayer.OMXPlayer(video_file_name)
+    video_file_name = request.json.get('video')
+    player = omx.Player(video_file_name)
 
-    return flask.jsonify(video=player.video, audio=player.audio)
+    return flask.jsonify(status='running', video=player.video, audio=player.audio)
 
-@app.route("/status", method="GET")
+
+@app.route("/transcode", methods=["POST"])
+def transcode():
+    global encoder
+    if encoder:
+        # stop encoding if a transcode task is still in progress
+        encoder.stop()
+    source_file = request.json.get('source_file')
+    target_file = request.json.get('target_file')
+    width = request.json.get('width', 800)
+    height = request.json.get('height', 600)
+    encoder = omx.Encoder(source_file, target_file,
+                          width=width, height=height)
+    return flask.jsonify(status='running')
+
+
+@app.route("/status", methods=["GET"])
 def status():
-
-    return flask.jsonify(ip=get_ip_address('eth0'))
+    global encoder, player
+    return flask.jsonify(ip_address=get_ip_address('eth0'),
+                         hardware_address=get_hardware_address('eth0'),
+                         encoder_active=encoder.is_active() if encoder else False,
+                         player_active=player.is_active() if player else False)
 
 if __name__ == "__main__":
     app.run()

--- a/video.py
+++ b/video.py
@@ -1,0 +1,48 @@
+import flask
+from flask import Flask
+import socket
+import fcntl
+import struct
+
+import pyomxplayer
+
+player = None
+
+
+def get_ip_address(ifname):
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    return socket.inet_ntoa(fcntl.ioctl(
+        s.fileno(),
+        0x8915,  # SIOCGIFADDR
+        struct.pack('256s', ifname[:15])
+    )[20:24])
+
+
+def get_hardware_address(ifname):
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    info = fcntl.ioctl(s.fileno(), 0x8927,  struct.pack('256s', ifname[:15]))
+    return ''.join(['%02x:' % ord(char) for char in info[18:24]])[:-1]
+
+
+app = Flask(__name__)
+
+#TODO: secure these routes such that only authorized clients may access
+@app.route("/play", method="POST")
+def play_video():
+    global player
+    if player:
+        # stop playback if a video has already been started
+        player.stop()
+
+    video_file_name = ''
+    player = pyomxplayer.OMXPlayer(video_file_name)
+
+    return flask.jsonify(video=player.video, audio=player.audio)
+
+@app.route("/status", method="GET")
+def status():
+
+    return flask.jsonify(ip=get_ip_address('eth0'))
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
These changes provide very basic capabilities for transcoding and playing videos on a Video Village Raspberry Pi via a JSON based API.   A very basic status API is also included to check on the player and encoder status.    The APIs make use of `omxplayer` and `gst-launch-1.0` (with `omxh264enc`) to play and encode video using the Pi's hardware capabilities.  
Initial testing shows a Raspberry Pi 2 has no trouble with video playback and encoding running in parallel.   See the README for some `curl` examples using the API
