### PR TITLE
Status reporting task and bug fixes

### DIFF
--- a/pivideo/__init__.py
+++ b/pivideo/__init__.py
@@ -20,7 +20,7 @@ import threading
 import time
 from urlparse import urlparse
 from pivideo import omx
-from pivideo.tasks import registration_task, fetch_show_schedule_task, setup_core_tasks
+from pivideo.tasks import setup_core_tasks
 from pivideo.projector import Projector
 
 FILE_CACHE = '/file_cache'

--- a/pivideo/sync.py
+++ b/pivideo/sync.py
@@ -13,10 +13,13 @@ logger = logging.getLogger(__name__)
 BASE_VILLAGE_URL = 'http://videovillage.seeingspartanburg.com'
 VILLAGE_REGISTER_ENDPOINT = '{0}/api/pis/register/'.format(BASE_VILLAGE_URL)
 VILLAGE_WINDOWS_ENDPOINT = '{0}/api/windows/'.format(BASE_VILLAGE_URL)
+VILLAGE_PI_STATUS_ENDPOINT = '{0}/api/pis/{1}/status/'.format(BASE_VILLAGE_URL, '{0}')
 
 VILLAGE_REQUEST_HEADERS = {
     'X-HUBOLOGY-VIDEO-VILLAGE-PI': PI_HARDWARE_ADDRESS
 }
+
+video_village_pi_id = None
 
 
 def register_pi():
@@ -26,13 +29,28 @@ def register_pi():
         video village pi id for later use.
     """
     global video_village_pi_id
-
     result = requests.post(VILLAGE_REGISTER_ENDPOINT,
                            headers=VILLAGE_REQUEST_HEADERS,
                            json={'mac_address': PI_HARDWARE_ADDRESS})
     if result.status_code == 200:
         registration_info = result.json()
         video_village_pi_id = registration_info.get('id')
+        return True
+
+    return False
+
+
+def report_current_pi_status():
+    """
+        Report current Pi status information to the Video Village system
+    """
+    global video_village_pi_id
+    from pivideo import current_status
+
+    result = requests.post(VILLAGE_PI_STATUS_ENDPOINT.format(video_village_pi_id),
+                           headers=VILLAGE_REQUEST_HEADERS,
+                           json=current_status())
+    if result.status_code == 200:
         return True
 
     return False

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,37 @@
+from __future__ import absolute_import
+import nose
+from pivideo.tasks import schedule_show
+import schedule
+
+
+def test_remove_overlapping_show_tasks():
+    """
+        Ensure on demand scheduling of a show removes any overlapping tasks
+    """
+    play_list_entries = [
+        {
+            "video": "https://s3.amazonaws.com:443/hubology-video-village-media/media/DJI_0127.MOV"
+        },
+        {
+            "photo": "https://s3.amazonaws.com/pivideo-testing/ssnl_logo.png",
+            "duration": 30
+        }
+    ]
+
+    initial_job_count = len(schedule.jobs)
+    schedule_show('20:00', '22:00', play_list_entries, loop=True)
+
+    job_count = len(schedule.jobs)
+    task_names = [job.job_func.func.func_name for job in schedule.jobs]
+    nose.tools.assert_equals(job_count, initial_job_count + 4)
+    nose.tools.assert_equals(task_names.count('cache_videos_task'), 1)
+    nose.tools.assert_equals(task_names.count('pre_show_task'), 1)
+    nose.tools.assert_equals(task_names.count('showtime_task'), 1)
+    nose.tools.assert_equals(task_names.count('post_show_task'), 1)
+
+    schedule_show('20:00', '22:00', play_list_entries, loop=True)
+    task_names = [job.job_func.func.func_name for job in schedule.jobs]
+    nose.tools.assert_equals(task_names.count('cache_videos_task'), 1)
+    nose.tools.assert_equals(task_names.count('pre_show_task'), 1)
+    nose.tools.assert_equals(task_names.count('showtime_task'), 1)
+    nose.tools.assert_equals(task_names.count('post_show_task'), 1)


### PR DESCRIPTION
- Support reporting Pi video status information to Video Village System on a periodic basis
- Clear out existing show tasks when submitting a new scheduled show to avoid overlap/duplicates
- stop playback before attempting to shutdown a connected projector during the post show task.  this will ensure proper operation when a projector is not in use.
