### PR TITLE
Proper support for show task set up based on downloaded schedule information

### DIFF
--- a/pivideo/api.py
+++ b/pivideo/api.py
@@ -9,7 +9,7 @@ from pivideo.networking import get_ip_address, get_hardware_address
 from pivideo import encoder, transcode_queue, photo_overlay, play_list
 from pivideo import omx
 from pivideo.projector import Projector
-from pivideo.tasks import schedule_show
+from pivideo.tasks import schedule_show, current_status, report_pi_status_task
 
 logger = logging.getLogger(__name__)
 
@@ -79,6 +79,8 @@ def projector_on():
             success = p.power_on()
     except:
         logger.exception('Unable to turn on projector.  Is it connected?')
+    finally:
+        report_pi_status_task()
 
     return flask.jsonify(status=success)
 
@@ -91,7 +93,9 @@ def projector_off():
             success = p.power_off()
     except:
         logger.exception('Unable to turn off projector.  Is it connected?')
-
+    finally:
+        report_pi_status_task()
+    
     return flask.jsonify(status=success)
 
 
@@ -109,5 +113,5 @@ def transcode():
 
 @app.route("/status", methods=["GET"])
 def status():
-    status_info = pivideo.current_status()
+    status_info = current_status()
     return flask.jsonify(status_info)

--- a/pivideo/sync.py
+++ b/pivideo/sync.py
@@ -45,7 +45,7 @@ def report_current_pi_status():
         Report current Pi status information to the Video Village system
     """
     global video_village_pi_id
-    from pivideo import current_status
+    from pivideo.tasks import current_status
 
     result = requests.post(VILLAGE_PI_STATUS_ENDPOINT.format(video_village_pi_id),
                            headers=VILLAGE_REQUEST_HEADERS,
@@ -69,9 +69,10 @@ def current_show_schedule():
                             'show_date': today.strftime('%Y-%m-%d')
                           })
 
-    logger.info('{0} {1}'.format(result.status_code, result.content))
+    logger.debug('GET {0} (Status {1}) {2}'.format(result.url, result.status_code, result.content))
     if result.status_code == 200:
         schedule_information = result.json()
-        return schedule_information
+        if len(schedule_information) == 1:
+            return schedule_information[0]
 
     return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 Flask==0.11.1
 Pillow==3.3.0
 arrow==0.8.0
+gpiozero==1.3.1
 gunicorn==19.6.0
+httmock==1.2.5
 pexpect==4.2.0
 pyserial==3.1.1
 nose==1.3.7

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,7 +1,60 @@
 from __future__ import absolute_import
+from httmock import all_requests, HTTMock
 import nose
-from pivideo.tasks import schedule_show
+from pivideo.tasks import schedule_show, fetch_show_schedule_task
 import schedule
+
+
+example_show_schedule_response = [
+    {
+        "id": 4,
+        "loop": False,
+        "offset_in_show": 0,
+        "playlist": {
+            "notes": "",
+            "title": "Test",
+            "videosegment_set": [
+                {
+                    "duration": 60,
+                    "offset_in_playlist": 0,
+                    "offset_in_video": 0,
+                    "video": {
+                        "address": "",
+                        "approved": False,
+                        "category": "",
+                        "city": "",
+                        "description": "Test run",
+                        "email": "testuser1@example.com",
+                        "file": "https://s3.amazonaws.com:443/hubology-video-village-media/media/IMG_6794.MOV",
+                        "id": 5,
+                        "length": None,
+                        "moderated_by": None,
+                        "moderation_notes": None,
+                        "phone": "",
+                        "state": None,
+                        "status": "s",
+                        "title": "submission test",
+                        "uploader_name": "Jane Doe",
+                        "zipcode": ""
+                    }
+                }
+            ]
+        },
+        "repeats": 5,
+        "show": {
+            "scheduleitem_set": [
+                {
+                    "date": "2016-09-16",
+                    "id": 4,
+                    "show": "   3: Hubology Test Show",
+                    "start_time": "20:15:00",
+                    "stop_time": "22:45:00"
+                }
+            ]
+        },
+        "window": 53
+    }
+]
 
 
 def test_remove_overlapping_show_tasks():
@@ -30,6 +83,33 @@ def test_remove_overlapping_show_tasks():
     nose.tools.assert_equals(task_names.count('post_show_task'), 1)
 
     schedule_show('20:00', '22:00', play_list_entries, loop=True)
+    task_names = [job.job_func.func.func_name for job in schedule.jobs]
+    nose.tools.assert_equals(task_names.count('cache_files_task'), 1)
+    nose.tools.assert_equals(task_names.count('pre_show_task'), 1)
+    nose.tools.assert_equals(task_names.count('showtime_task'), 1)
+    nose.tools.assert_equals(task_names.count('post_show_task'), 1)
+
+
+def test_map_play_list_information():
+    """
+        Verify proper mapping of Pi Window Schedule Information to a set of show tasks
+    """
+    # clear any currently scheduled items
+    schedule.clear()
+
+    # set up a mock Pi Windows API response for testing
+    @all_requests
+    def window_response_content(url, request):
+        return {
+            'status_code': 200,
+            'content': example_show_schedule_response
+        }
+
+    # fire off the task that periodically checks for show updates
+    with HTTMock(window_response_content):
+        fetch_show_schedule_task()
+
+    # verify we have the proper tasks queued up to run the show
     task_names = [job.job_func.func.func_name for job in schedule.jobs]
     nose.tools.assert_equals(task_names.count('cache_files_task'), 1)
     nose.tools.assert_equals(task_names.count('pre_show_task'), 1)


### PR DESCRIPTION
These changes add proper support for setting up scheduled tasks to run a show at a time in the future.   Additional improvements were added for on boot task firing to download schedule information and publish current status information.  File cache contents are now included in status information along with current CPU temperature.   Test coverage was bumped up to around 60% overall
