### PR TITLE
Add POST /sync API to allow for on demand sync'ing of show schedule information and pi status

### DIFF
--- a/pivideo/api.py
+++ b/pivideo/api.py
@@ -11,7 +11,8 @@ from pivideo.networking import get_ip_address, get_hardware_address
 from pivideo import encoder, transcode_queue, photo_overlay, play_list, FILE_CACHE
 from pivideo import omx
 from pivideo.projector import Projector
-from pivideo.tasks import schedule_show, current_status, report_pi_status_task
+from pivideo.tasks import (schedule_show, current_status, report_pi_status_task,
+                           fetch_show_schedule_task)
 
 logger = logging.getLogger(__name__)
 
@@ -135,3 +136,8 @@ def delete_cache():
         return flask.jsonify({
             "removed_files": removed_files
         })
+
+@app.route("/sync", methods=["POST"])
+def synchronize_schedule_and_status():
+    fetch_show_schedule_task()
+    return flask.jsonify(status='ok')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -99,3 +99,14 @@ def test_delete_file_cache():
         nose.tools.assert_equals(200, response.status_code)
         response_data = json.loads(response.data)
         nose.tools.assert_in('removed_files', response_data)
+
+
+def test_sync():
+    """
+        Verify proper handling of a POST /sync request to fetch the latest schedule information and push back status information
+    """
+    with app.test_client() as client:
+        response = client.post('/sync', data=json.dumps({}), content_type='application/json')
+        nose.tools.assert_equals(200, response.status_code)
+        response_data = json.loads(response.data)
+        nose.tools.assert_equals('ok', response_data['status'])


### PR DESCRIPTION
This resolves #37 and adds a new API to allow for on demand sync'ing of show schedule information.
This will also sync up the pi's status with the video village system.
