### PR TITLE
initial support for video streaming capabilities

### DIFF
--- a/pi-video-setup.sh
+++ b/pi-video-setup.sh
@@ -52,7 +52,8 @@ sudo cp pngview /usr/local/bin/
 cd -
 
 #Set up Python related components
-sudo apt-get install -y libffi5 python-virtualenv
+sudo apt-get install -y libffi5 python-virtualenv python-pip
+sudo pip install streamlink
 curl -L https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.1-linux-armhf-raspbian.tar.bz2 \
      -o pypy2-v5.3.1-linux-armhf-raspbian.tar.bz2
 sudo tar -xjf pypy2-v5.3.1-linux-armhf-raspbian.tar.bz2 -C /usr/local --strip-components=1

--- a/pivideo/api.py
+++ b/pivideo/api.py
@@ -18,6 +18,8 @@ logger = logging.getLogger(__name__)
 
 app = Flask(__name__)
 
+streamer = None
+
 
 @app.route("/overlay", methods=["POST"])
 def overlay():
@@ -141,3 +143,24 @@ def delete_cache():
 def synchronize_schedule_and_status():
     fetch_show_schedule_task()
     return flask.jsonify(status='ok')
+
+
+@app.route("/stream", methods=["POST"])
+def play_video_stream():
+    global streamer
+    global play_list
+
+    # stop playback if active
+    if play_list:
+        play_list.stop()
+
+    # stop playback of current stream if active
+    if streamer:
+        streamer.stop()
+
+    video = request.json.get('video')
+    if video:
+        streamer = omx.Streamer(video)
+        return flask.jsonify(status='running')
+    else:
+        return flask.jsonify(status='stopped')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -110,3 +110,14 @@ def test_sync():
         nose.tools.assert_equals(200, response.status_code)
         response_data = json.loads(response.data)
         nose.tools.assert_equals('ok', response_data['status'])
+
+
+def test_stream_stop():
+    """
+        Verify stream API stop operation when no video has been played
+    """
+    with app.test_client() as client:
+        response = client.post('/stream', data=json.dumps({}), content_type='application/json')
+        nose.tools.assert_equals(200, response.status_code)
+        response_data = json.loads(response.data)
+        nose.tools.assert_equals('stopped', response_data['status'])


### PR DESCRIPTION
This is the initial work to be able to evaluate `streamlink` + `omxplayer` for playing (live) video streams on the Pis.   This is currently only supported via the POST /stream API and not in scheduled show playback.   This should resolve #36 for initial live streaming capabilities.  
A separate playbook will be created to install `streamlink` on the Pis so that it may be used in combination with omxplayer.  

I've verified this works with YouTube Live streams but I've not yet been able to make it work with things like periscope.   We may need to review that and push back some other adjustments if we'd like that to work also.
